### PR TITLE
Add deploy to 1_9, 1_10 and 2_0 packagecloud repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,12 @@ env:
     matrix:
       - OS=el DIST=6
       - OS=el DIST=7
-      - OS=fedora DIST=24
-      - OS=fedora DIST=25
-      - OS=ubuntu DIST=precise
+      - OS=fedora DIST=26
+      - OS=fedora DIST=27
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
-      - OS=ubuntu DIST=yakkety
-      - OS=ubuntu DIST=zesty
       - OS=ubuntu DIST=artful
+      - OS=ubuntu DIST=bionic
       - OS=debian DIST=wheezy
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
@@ -70,7 +68,27 @@ deploy:
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
   - provider: packagecloud
     username: tarantool
-    repository: "1_8"
+    repository: "1_9"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{deb,dsc,rpm}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "1_10"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{deb,dsc,rpm}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_0"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{deb,dsc,rpm}


### PR DESCRIPTION
Removed end of life ubuntu releases: Yakkety, Precise and Zesty. Added Ubuntu Bionic.
Also removed unsupported Fedora releases: 24 and 25. Added Fedora releases 26 and 27.