### PR TITLE
travis-ci: update distributives and repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,15 @@ env:
       - OS=el DIST=7
       - OS=fedora DIST=26
       - OS=fedora DIST=27
+      - OS=fedora DIST=28
+      - OS=fedora DIST=29
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
-      - OS=ubuntu DIST=artful
       - OS=ubuntu DIST=bionic
-      - OS=debian DIST=wheezy
+      - OS=ubuntu DIST=cosmic
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
-
-#matrix:
-#    allow_failures:
-#      - env: OS=el DIST=6
-#      - env: OS=el DIST=7
-#      - env: OS=fedora DIST=23
-#      - env: OS=fedora DIST=24
-#      - env: OS=fedora DIST=25
-#      - env: OS=ubuntu DIST=precise
-#      - env: OS=ubuntu DIST=trusty
-#      - env: OS=ubuntu DIST=xenial
-#      - env: OS=ubuntu DIST=yakkety
-#      - env: OS=debian DIST=wheezy
-#      - env: OS=debian DIST=jessie
-#      - env: OS=debian DIST=stretch
+      - OS=debian DIST=buster
 
 script:
   - git describe --long
@@ -89,6 +76,16 @@ deploy:
   - provider: packagecloud
     username: tarantool
     repository: "2x"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{deb,dsc,rpm}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_2"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{deb,dsc,rpm}


### PR DESCRIPTION
Removed EOL distributives, added new ones.

Deploy the library into the new 2_2 repository.