### PR TITLE
travis-ci: update distributives and repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,18 @@ env:
     matrix:
       - OS=el DIST=6
       - OS=el DIST=7
+      - OS=el DIST=8
       - OS=fedora DIST=26
       - OS=fedora DIST=27
       - OS=fedora DIST=28
       - OS=fedora DIST=29
       - OS=fedora DIST=30
+      - OS=fedora DIST=31
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=cosmic
       - OS=ubuntu DIST=disco
+      - OS=ubuntu DIST=eoan
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
       - OS=debian DIST=buster
@@ -88,6 +90,26 @@ deploy:
   - provider: packagecloud
     username: tarantool
     repository: "2_2"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{deb,dsc,rpm}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_3"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{deb,dsc,rpm}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{deb,dsc,rpm}


### PR DESCRIPTION
* Added CentOS 8, Fedora 31, Ubuntu Eoan (19.10) to deploy jobs.
* Added 2_3 and 2_4 tarantool repositories to deploy into.
* Removed Ubuntu Cosmic (18.10) -- it is EOL.