### PR TITLE
travis-ci: remove Ubuntu Disco, add Ubuntu Focal (20.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
       - OS=ubuntu DIST=eoan
+      - OS=ubuntu DIST=focal
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
       - OS=debian DIST=buster

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=disco
       - OS=ubuntu DIST=eoan
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch


### PR DESCRIPTION
Removed Ubuntu Disco.
Added Ubuntu Focal (20.04).

Requested in https://github.com/tarantool/tarantool/issues/4863