### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(msgpuck)
+project(msgpuck C)
 cmake_minimum_required(VERSION 2.8.5)
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")


### PR DESCRIPTION
Adds 'C' in project() statement in CMakeLists.txt

Fixes bug when CMake was trying to find C++ compiler while preparing packages 
for Opensuse 15.1 and 15.2 and fails. 

Needed for packaging workflow in tarantool-c:
https://github.com/tarantool/tarantool-c/issues/145