### PR TITLE
Add 'C' into project() in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(msgpuck)
+project(msgpuck C)
 cmake_minimum_required(VERSION 2.8.5)
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")


### PR DESCRIPTION
Msgpuck is a submodule for tarantool-c and is needed while packaging.
Fixes bug when CMake was trying to find C++ compiler while preparing
tarantool-c packages for Opensuse 15.1 and 15.2 and fails.
C++ language may be excluded in case of only C necessarity.

Needed for packaging workflow in tarantool/tarantool-c:
https://github.com/tarantool/tarantool-c/issues/145