### PR TITLE
Introduce MP_EXT validation capabilities

### DIFF
--- a/msgpuck.c
+++ b/msgpuck.c
@@ -59,6 +59,17 @@ mp_fprint_ext_f mp_fprint_ext = mp_fprint_ext_default;
 
 mp_snprint_ext_f mp_snprint_ext = mp_snprint_ext_default;
 
+int
+mp_check_ext_data_default(int8_t type, const char *data, uint32_t len)
+{
+	(void)data;
+	(void)type;
+	(void)len;
+	return 0;
+}
+
+mp_check_ext_data_f mp_check_ext_data = mp_check_ext_data_default;
+
 size_t
 mp_vformat(char *data, size_t data_size, const char *format, va_list vl)
 {


### PR DESCRIPTION
Currently mp_check() checks that the given buffer is a valid msgpack
string, however it simply skips MP_EXT fields, since it knows nothing
of their contents.

Let's introduce a stub for checking MP_EXT contents.
The stub will be replaced with an application-defined callback checking
the ext types it has introduced.

Needed for tarantool/tarantool#6857