### PR TITLE
Introduce toggle for escaping '/'

### DIFF
--- a/hints.c
+++ b/hints.c
@@ -650,7 +650,7 @@ const int8_t mp_parser_hint[256] = {
 	/* }}} */
 };
 
-const char *mp_char2escape[128] = {
+char *mp_char2escape[128] = {
 	"\\u0000", "\\u0001", "\\u0002", "\\u0003",
 	"\\u0004", "\\u0005", "\\u0006", "\\u0007",
 	"\\b", "\\t", "\\n", "\\u000b",
@@ -660,7 +660,7 @@ const char *mp_char2escape[128] = {
 	"\\u0018", "\\u0019", "\\u001a", "\\u001b",
 	"\\u001c", "\\u001d", "\\u001e", "\\u001f",
 	NULL, NULL, "\\\"", NULL, NULL, NULL, NULL, NULL,
-	NULL, NULL, NULL, NULL, NULL, NULL, NULL, "\\/",
+	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,

--- a/msgpuck.c
+++ b/msgpuck.c
@@ -415,3 +415,14 @@ mp_snprint(char *buf, int size, const char *data)
 {
 	return mp_snprint_recursion(buf, size, &data, MP_PRINT_MAX_DEPTH);
 }
+
+static const char escaped_slash[] = "\\/";
+
+void
+msgpuck_json_esc_slash_toggle(bool value)
+{
+        if (value)
+                mp_char2escape['/'] = (char*)escaped_slash;
+        else
+                mp_char2escape['/'] = NULL;
+}

--- a/msgpuck.h
+++ b/msgpuck.h
@@ -1484,8 +1484,10 @@ mp_frame_advance(struct mp_frame *frame);
 /** \cond false */
 extern const enum mp_type mp_type_hint[];
 extern const int8_t mp_parser_hint[];
-extern const char *mp_char2escape[];
+extern char *mp_char2escape[];
 extern const uint8_t mp_ext_hint[];
+
+void msgpuck_json_esc_slash_toggle(bool value);
 
 MP_IMPL MP_ALWAYSINLINE enum mp_type
 mp_typeof(const char c)


### PR DESCRIPTION
It was decided that lua_cjson should have tarantool.compat (tarantool/tarantool#7000)
option that allows to toggle escaping '/'. For consistency msgpuck is to
switch the behavior too.

This patch provides function that sets '/' to be escaped or not.

Needed for tarantool/tarantool#6200