### PR TITLE
Make mp_check fail on 0xc1

### DIFF
--- a/hints.c
+++ b/hints.c
@@ -554,7 +554,7 @@ const int8_t mp_parser_hint[256] = {
 
 	/* {{{ MP_NIL, MP_BOOL */
 	/* 0xc0 */ 0, /* MP_NIL */
-	/* 0xc1 */ 0, /* never used */
+	/* 0xc1 */ MP_HINT_INVALID, /* never used */
 	/* 0xc2 */ 0, /* MP_BOOL*/
 	/* 0xc3 */ 0, /* MP_BOOL*/
 	/* }}} */

--- a/msgpuck.h
+++ b/msgpuck.h
@@ -2395,7 +2395,8 @@ enum {
 	MP_HINT_MAP_32 = MP_HINT - 6,
 	MP_HINT_EXT_8 = MP_HINT - 7,
 	MP_HINT_EXT_16 = MP_HINT - 8,
-	MP_HINT_EXT_32 = MP_HINT - 9
+	MP_HINT_EXT_32 = MP_HINT - 9,
+	MP_HINT_INVALID = MP_HINT - 10
 };
 
 MP_PROTO void
@@ -2646,6 +2647,8 @@ mp_check(const char **data, const char *end)
 				return 1;
 			*data += len;
 			break;
+		case MP_HINT_INVALID:
+			return 1;
 		default:
 			mp_unreachable();
 		}

--- a/test/msgpuck.c
+++ b/test/msgpuck.c
@@ -1055,7 +1055,7 @@ test_mp_print_ext(void)
 int
 test_mp_check()
 {
-	plan(65);
+	plan(69);
 	header();
 
 #define invalid(data, fmt, ...) ({ \
@@ -1190,6 +1190,12 @@ test_mp_check()
 	invalid("\xdf", "invalid map32 1");
 	invalid("\xdf\x00\x00\x00\x01", "invalid map32 2");
 	invalid("\xdf\x00\x00\x00\x01\x5", "invalid map32 3");
+
+	/* 0xc1 is never used */
+	invalid("\xc1", "invalid header 1");
+	invalid("\x91\xc1", "invalid header 2");
+	invalid("\x93\xff\xc1\xff", "invalid header 3");
+	invalid("\x82\xff\xc1\xff\xff", "invalid header 4");
 
 	footer();
 


### PR DESCRIPTION
0xc1 is reserved and should never be used in any valid MsgPack.

Closes #13
Needed for https://github.com/tarantool/tarantool/issues/7818