### PR TITLE
Fix integer overflow in mp_check and mp_next for MP_MAP

### DIFF
--- a/msgpuck.h
+++ b/msgpuck.h
@@ -2483,11 +2483,11 @@ mp_next_slowpath(const char **data, int64_t k)
 			break;
 		case MP_HINT_MAP_16:
 			/* MP_MAP (16) */
-			k += 2 * mp_load_u16(data);
+			k += 2 * (uint32_t)mp_load_u16(data);
 			break;
 		case MP_HINT_MAP_32:
 			/* MP_MAP (32) */
-			k += 2 * mp_load_u32(data);
+			k += 2 * (uint64_t)mp_load_u32(data);
 			break;
 		case MP_HINT_EXT_8:
 			/* MP_EXT (8) */
@@ -2610,12 +2610,12 @@ mp_check(const char **data, const char *end)
 		case MP_HINT_MAP_16:
 			/* MP_MAP (16) */
 			MP_CHECK_LEN(sizeof(uint16_t));
-			k += 2 * mp_load_u16(data);
+			k += 2 * (uint32_t)mp_load_u16(data);
 			break;
 		case MP_HINT_MAP_32:
 			/* MP_MAP (32) */
 			MP_CHECK_LEN(sizeof(uint32_t));
-			k += 2 * mp_load_u32(data);
+			k += 2 * (uint64_t)mp_load_u32(data);
 			break;
 		case MP_HINT_EXT_8:
 			/* MP_EXT (8) */

--- a/test/msgpuck.c
+++ b/test/msgpuck.c
@@ -1055,7 +1055,7 @@ test_mp_print_ext(void)
 int
 test_mp_check()
 {
-	plan(69);
+	plan(71);
 	header();
 
 #define invalid(data, fmt, ...) ({ \
@@ -1184,12 +1184,14 @@ test_mp_check()
 	/* map16 */
 	invalid("\xde", "invalid map16 1");
 	invalid("\xde\x00\x01", "invalid map16 2");
-	invalid("\xde\x00\x01\x5", "invalid map16 2");
+	invalid("\xde\x00\x01\x5", "invalid map16 3");
+	invalid("\xde\x80\x00", "invalid map16 4");
 
 	/* map32 */
 	invalid("\xdf", "invalid map32 1");
 	invalid("\xdf\x00\x00\x00\x01", "invalid map32 2");
 	invalid("\xdf\x00\x00\x00\x01\x5", "invalid map32 3");
+	invalid("\xdf\x80\x00\x00\x00", "invalid map32 4");
 
 	/* 0xc1 is never used */
 	invalid("\xc1", "invalid header 1");


### PR DESCRIPTION
An MP_MAP header encodes the number of pairs stored in the map so we multiply the value by 2 in mp_next and mp_check. The problem is that we don't extend the integer value before peforming multiplication so it can lead to an integer overflow and, as a result, mp_check fails to detect invalid MsgPack data. Fix this.

Note, we only add a test for mp_check, because adding a test for mp_next would make it consume too much memory (> 4GB).

Needed for https://github.com/tarantool/security/issues/18