### PR TITLE
Don't escape forward slash in `mp_snprint`

### DIFF
--- a/hints.c
+++ b/hints.c
@@ -660,7 +660,7 @@ const char *mp_char2escape[128] = {
 	"\\u0018", "\\u0019", "\\u001a", "\\u001b",
 	"\\u001c", "\\u001d", "\\u001e", "\\u001f",
 	NULL, NULL, "\\\"", NULL, NULL, NULL, NULL, NULL,
-	NULL, NULL, NULL, NULL, NULL, NULL, NULL, "\\/",
+	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,

--- a/hints.c
+++ b/hints.c
@@ -650,7 +650,7 @@ const int8_t mp_parser_hint[256] = {
 	/* }}} */
 };
 
-const char *mp_char2escape[128] = {
+const char *const mp_char2escape[128] = {
 	"\\u0000", "\\u0001", "\\u0002", "\\u0003",
 	"\\u0004", "\\u0005", "\\u0006", "\\u0007",
 	"\\b", "\\t", "\\n", "\\u000b",

--- a/msgpuck.h
+++ b/msgpuck.h
@@ -1499,7 +1499,7 @@ mp_frame_advance(struct mp_frame *frame);
 /** \cond false */
 extern const enum mp_type mp_type_hint[];
 extern const int8_t mp_parser_hint[];
-extern const char *mp_char2escape[];
+extern const char *const mp_char2escape[];
 extern const uint8_t mp_ext_hint[];
 
 MP_IMPL MP_ALWAYSINLINE enum mp_type

--- a/test/msgpuck.c
+++ b/test/msgpuck.c
@@ -868,7 +868,7 @@ test_mp_print()
 	d = mp_encode_array(d, 8);
 	d = mp_encode_int(d, -5);
 	d = mp_encode_uint(d, 42);
-	d = mp_encode_str(d, "kill bill", 9);
+	d = mp_encode_str(d, "kill/bill", 9);
 	d = mp_encode_array(d, 0);
 	d = mp_encode_map(d, 6);
 	d = mp_encode_str(d, "bool true", 9);
@@ -893,7 +893,7 @@ test_mp_print()
 	assert(d <= msgpack + sizeof(msgpack));
 
 	const char *expected =
-		"[-5, 42, \"kill bill\", [], "
+		"[-5, 42, \"kill/bill\", [], "
 		"{\"bool true\": true, \"bool false\": false, \"null\": null, "
 		"\"float\": 3.14, \"double\": 3.14, 100: 500}, "
 		"(extension: type 123, len 3), "


### PR DESCRIPTION
`mp_snprint` formats MsgPack data as a JSON-like string. According to the JSON format, the forward slash character isn't supposed to be escaped, but `mp_snprint` does escape it. Let's fix this.

Note, this should be fine from the Tarantool compatibility point of view, because Tarantool uses this function only for presenting MsgPack data in an unspecified human-readable format, e.g. when printing to the log. If we need to format MsgPack data as valid JSON, we should use the internal Tarantool JSON encoder which respects the JSON serializer config and compat module options.

See https://github.com/tarantool/tarantool/issues/6200

While we are at it, let's also constify `mp_char2escape`, because it's an internal table, which shouldn't be modified by library users.