### PR TITLE
Add mp_can_read_double

### DIFF
--- a/msgpuck.h
+++ b/msgpuck.h
@@ -1584,6 +1584,15 @@ MP_PROTO int
 mp_read_double(const char **data, double *ret);
 
 /**
+ * \brief Check if a value from MsgPack \a data is loselessly convertible
+ *        to double.
+ * \param data - the pointer to a buffer
+ * \retval true if the value is convertible, false otherwise.
+ */
+MP_PROTO bool
+mp_can_read_double(const char *data);
+
+/**
  * \brief Skip one element in a packed \a data.
  *
  * The function is faster than mp_typeof + mp_decode_XXX() combination.
@@ -2843,6 +2852,44 @@ mp_read_double(const char **data, double *ret)
 	}
 	*data = p;
 	return 0;
+}
+
+MP_IMPL bool
+mp_can_read_double(const char *data)
+{
+	int64_t ival;
+	uint64_t uval;
+	double val;
+	const char *p = data;
+	uint8_t c = mp_load_u8(&p);
+	switch (c) {
+	case 0xca: /* float */
+	case 0xcb: /* double */
+	case 0xd0: /* int 8 */
+	case 0xd1: /* int 16 */
+	case 0xd2: /* int 32 */
+	case 0xcc: /* uint 8 */
+	case 0xcd: /* uint 16 */
+	case 0xce: /* uint 32 */
+		return true;
+	case 0xd3:
+		ival = (int64_t)mp_load_u64(&p);
+		val = (double)ival;
+		if (mp_unlikely((int64_t)val != ival))
+			return false;
+		return true;
+	case 0xcf:
+		uval = mp_load_u64(&p);
+		val = (double)uval;
+		if (mp_unlikely((uint64_t)val != uval))
+			return false;
+		return true;
+	default:
+		if (mp_unlikely(c < 0xe0 && c > 0x7f))
+			return false;
+		return true;
+	}
+	mp_unreachable();
 }
 
 /** See mp_parser_hint */

--- a/test/msgpuck.c
+++ b/test/msgpuck.c
@@ -1476,12 +1476,18 @@ test_mp_check_ext_data()
 
 #define test_read_int32(...)	test_read_number(mp_read_int32, int_eq, int32_t, __VA_ARGS__)
 #define test_read_int64(...)	test_read_number(mp_read_int64, int_eq, int64_t, __VA_ARGS__)
-#define test_read_double(...)	test_read_number(mp_read_double, double_eq, double, __VA_ARGS__)
+
+#define test_read_double(_mp_type, _val, _success) do {					\
+	mp_encode_##_mp_type(data, _val);						\
+	is(mp_can_read_double(data), _success, "mp_can_read_double(%s) gives %s",	\
+	   #_val, #_success);								\
+	test_read_number(mp_read_double, double_eq, double, _mp_type, _val, _success);	\
+} while (0)
 
 static int
 test_numbers()
 {
-	plan(96);
+	plan(109);
 	header();
 
 	test_read_int32(uint, 123, true);


### PR DESCRIPTION
Add a new function to check if MsgPack data (whether it's integer or floating point) can be loselessly converted to double. The effect of the function is equivalent to this:

```C
const char *p = data;
double dummy;
return mp_read_double(&p, &dummy) == 0;
```

Just a syntactic sugar if the compiler is smart enough to duplicate the `mp_read_double` with unused stores removed (or just inline it and eliminate unused variables).