### PR TITLE
Add mp_read_double_lossy without direct convertibility checks

### DIFF
--- a/test/msgpuck.c
+++ b/test/msgpuck.c
@@ -1474,14 +1474,15 @@ test_mp_check_ext_data()
 	}								\
 } while (0)
 
-#define test_read_int32(...)	test_read_number(mp_read_int32, int_eq, int32_t, __VA_ARGS__)
-#define test_read_int64(...)	test_read_number(mp_read_int64, int_eq, int64_t, __VA_ARGS__)
-#define test_read_double(...)	test_read_number(mp_read_double, double_eq, double, __VA_ARGS__)
+#define test_read_int32(...)        test_read_number(mp_read_int32, int_eq, int32_t, __VA_ARGS__)
+#define test_read_int64(...)        test_read_number(mp_read_int64, int_eq, int64_t, __VA_ARGS__)
+#define test_read_double(...)       test_read_number(mp_read_double, double_eq, double, __VA_ARGS__)
+#define test_read_double_lossy(...) test_read_number(mp_read_double_lossy, double_eq, double, __VA_ARGS__)
 
 static int
 test_numbers()
 {
-	plan(96);
+	plan(134);
 	header();
 
 	test_read_int32(uint, 123, true);
@@ -1522,6 +1523,20 @@ test_numbers()
 	test_read_double(float, 6.565e6, true);
 	test_read_double(double, -5.555, true);
 	test_read_double(strl, 100, false);
+
+	test_read_double_lossy(uint, 123, true);
+	test_read_double_lossy(uint, 12345, true);
+	test_read_double_lossy(uint, 123456789, true);
+	test_read_double_lossy(uint, 1234567890000ULL, true);
+	test_read_double_lossy(uint, 123456789123456789ULL, true);
+	test_read_double_lossy(int, -123, true);
+	test_read_double_lossy(int, -12345, true);
+	test_read_double_lossy(int, -123456789, true);
+	test_read_double_lossy(int, -1234567890000LL, true);
+	test_read_double_lossy(int, -123456789123456789LL, true);
+	test_read_double_lossy(float, 6.565e6, true);
+	test_read_double_lossy(double, -5.555, true);
+	test_read_double_lossy(strl, 100, false);
 
 	footer();
 	return check_plan();


### PR DESCRIPTION
The function is similar to mp_read_double but it does not fail if the conversion is impossible without data loss.

The constant argument is easy to optimize for modern gcc and clang, but not mvcc ([proof](https://godbolt.org/z/jhYcEMh85)).

Another way to prevent duplication is to use a macro like here: ([msgpuck.c +272](https://github.com/tarantool/msgpuck/blob/0c6680a300e31714f475a7f90c2d95a02d001d80/msgpuck.c#L272)), if one don't want to rely on compiler optimizations.