### PR TITLE
Fix mp_read_double_lossy tests freebsd build

### DIFF
--- a/test/msgpuck.c
+++ b/test/msgpuck.c
@@ -1467,7 +1467,7 @@ test_mp_check_ext_data()
 	if (_success) {							\
 		is(ret, 0, "%s check success", s);			\
 		is(d1, d2, "%s check pos advanced", s);			\
-		ok(_eq(v, _val), "%s check result", s);		\
+		ok(_eq(v, (_type)_val), "%s check result", s);		\
 	} else {							\
 		is(ret, -1, "%s check fail", s);			\
 		is(d1, data, "%s check pos unchanged", s);		\


### PR DESCRIPTION
Since the mp_read_double_lossy test performs lossy read from the msgpack, the value it reads is not strictly equal to the one we compare it with sometimes, which leads to lossy implicit cast on values equality check.

Fixed this by explicitly casting the value to compare the read result with to double.