### PR TITLE
cmake: update the minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(msgpuck C CXX)
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.5)
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -fPIC -fstrict-aliasing")


### PR DESCRIPTION
For CMake 4.0, compatibility with versions of CMake older than 3.5 has been removed [1]. Thus, on macOS it leads to the error on build, since Homebrew updates it to version 4.0.

This patch sets the minimum required version to 3.5 for now.

[1]: https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features