### PR TITLE
perf: add perf tests for mp_next/mp_check of UINTs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(msgpuck STATIC msgpuck.c hints.c)
 set_target_properties(msgpuck PROPERTIES VERSION 1.0 SOVERSION 1)
 set_target_properties(msgpuck PROPERTIES OUTPUT_NAME "msgpuck")
 
+add_subdirectory(perf)
+
 if (NOT ${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     # Embedded mode, skip tests, documentation and the install targets
     return()

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(CMAKE_CXX_STANDARD 11)
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(AUTHOR_WARNING "Benchmark available only in release build")
+    return()
+endif()
+
+# Handle a case when BENCHMARK_LIBRARIES, BENCHMARK_INCLUDE_DIRS
+# and benchmark_FOUND are defined in the parent project, like in
+# the Tarantool, that uses the bundled Benchmark library.
+if (NOT benchmark_FOUND)
+    find_package(benchmark QUIET)
+    if (NOT benchmark_FOUND)
+        message(AUTHOR_WARNING "Google Benchmark library not found")
+        return()
+    endif()
+    set(BENCHMARK_LIBRARIES benchmark::benchmark)
+endif()
+
+include_directories("${PROJECT_SOURCE_DIR}")
+
+add_executable(msgpuck.perftest msgpuck.cc)
+target_link_libraries(msgpuck.perftest msgpuck ${BENCHMARK_LIBRARIES} pthread)
+target_include_directories(msgpuck.perftest PUBLIC ${BENCHMARK_INCLUDE_DIRS})

--- a/perf/msgpuck.cc
+++ b/perf/msgpuck.cc
@@ -1,0 +1,123 @@
+#include <benchmark/benchmark.h>
+#include <random>
+#include <functional>
+
+#include "msgpuck.h"
+
+#define DATA_SIZE (128 * 1024 * 1024)
+
+static auto generator = std::mt19937_64{};
+
+struct data_set {
+	char *data;
+	char *end;
+	char *buf_end;
+	int count;
+};
+
+static void
+data_set_create(struct data_set *set)
+{
+	set->data = (char *)malloc(DATA_SIZE);
+	set->buf_end = set->data + DATA_SIZE;
+	/* No any data on creation. */
+	set->end = set->data;
+	set->count = 0;
+}
+
+static void
+data_set_destroy(struct data_set *set)
+{
+	free(set->data);
+}
+
+template<class Generator>
+static void
+data_set_reset(struct data_set *set, Generator gen)
+{
+	set->count = 0;
+	set->end = set->data;
+	while (true) {
+		size_t size = gen(set->end, set->buf_end);
+		if (size == 0)
+			break;
+		set->end += size;
+		set->count++;
+	}
+}
+
+static uint64_t
+uint_max(int bits)
+{
+	if (bits == 64)
+		return UINT64_MAX;
+	else
+		return (1ULL << bits) - 1;
+}
+
+template<class UintDist>
+static size_t
+mp_uint_generate(char *buf, char *buf_end, UintDist dist)
+{
+	uint64_t v = dist(generator);
+	size_t size = mp_sizeof_uint(v);
+	if (buf + size > buf_end)
+		return 0;
+	mp_encode_uint(buf, v);
+	return size;
+}
+
+static void
+bench_mp_next_uint(benchmark::State& state)
+{
+	using namespace std::placeholders;
+	struct data_set set;
+	data_set_create(&set);
+
+	/** The test parametrized by number of bits in UINT. */
+	int bits = state.range(0);
+	auto dist = std::uniform_int_distribution<uint64_t>(0, uint_max(bits));
+	data_set_reset(&set,
+		       std::bind(mp_uint_generate<decltype(dist)>, _1, _2,
+			         dist));
+
+	for (auto _ : state) {
+		const char *d = set.data;
+		for (int i = 0; i < set.count; i++)
+			mp_next(&d);
+	}
+	state.SetItemsProcessed(state.iterations() * set.count);
+
+	data_set_destroy(&set);
+}
+
+static void
+bench_mp_check_uint(benchmark::State& state)
+{
+	using namespace std::placeholders;
+	struct data_set set;
+	data_set_create(&set);
+
+	/** The test parametrized by number of bits in UINT. */
+	int bits = state.range(0);
+	auto dist = std::uniform_int_distribution<uint64_t>(0, uint_max(bits));
+	data_set_reset(&set,
+		       std::bind(mp_uint_generate<decltype(dist)>, _1, _2,
+			         dist));
+
+	for (auto _ : state) {
+		const char *d = set.data;
+		for (int i = 0; i < set.count; i++) {
+			if (mp_check(&d, set.end) != 0)
+				abort();
+		}
+	}
+	state.SetItemsProcessed(state.iterations() * set.count);
+
+	data_set_destroy(&set);
+}
+
+BENCHMARK(bench_mp_next_uint)->Arg(7)->Arg(16)->Arg(32)->Arg(64);
+BENCHMARK(bench_mp_check_uint)->Arg(7)->Arg(16)->Arg(32)->Arg(64);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This gives us insight on how fast the library performs in this case.

```
Running ./build-release/perf/msgpuck.perftest
Run on (8 X 1701.41 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 0.18, 0.27, 0.24
---------------------------------------------------------------------------------
Benchmark                       Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------
bench_mp_next_uint/7    879986586 ns    877002214 ns            1 items_per_second=153.041M/s
bench_mp_next_uint/16   298739842 ns    297506631 ns            2 items_per_second=150.675M/s
bench_mp_next_uint/32   181359317 ns    180506035 ns            4 items_per_second=148.714M/s
bench_mp_next_uint/64   103291897 ns    102874492 ns            7 items_per_second=144.964M/s
bench_mp_check_uint/7  1256330299 ns   1252044428 ns            1 items_per_second=107.199M/s
bench_mp_check_uint/16  416581848 ns    414885146 ns            2 items_per_second=108.046M/s
bench_mp_check_uint/32  254512660 ns    253335815 ns            3 items_per_second=105.961M/s
bench_mp_check_uint/64  139501850 ns    138913918 ns            5 items_per_second=107.355M/s
```

See also msgpuck bump in Tarantool in https://github.com/tarantool/tarantool/pull/11811.